### PR TITLE
Add Dockerfiles for B2HANDLE library, docs and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# vim:set ft=dockerfile:
+FROM       debian:jessie
+
+RUN        apt-get update && apt-get install -y --no-install-recommends \
+           ca-certificates \
+           python \
+           python-setuptools \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+ADD        . /opt/B2HANDLE
+
+WORKDIR    /opt/B2HANDLE
+
+RUN        python setup.py install

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # B2HANDLE
+
+
+## Docker
+The [Dockerfile](Dockerfile) contains instructions for building a [Docker](https://www.docker.com/) image with the B2HANDLE library installed.
+
+
+### Base Docker Image
+
+* [debian:jessie](https://hub.docker.com/_/debian/)
+
+
+### Installation
+
+1. Install [Docker](https://www.docker.com/).
+
+2. Build an image from Dockerfile: `docker build -t eudat-b2handle .`
+
+
+#### Running `python`
+
+    docker run -it --rm eudat-b2handle python
+
+    Python 2.7.9 (default, Mar  1 2015, 12:57:24) 
+    [GCC 4.9.2] on linux2
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> from b2handle.handleclient import EUDATHandleClient
+    >>>

--- a/b2handle/tests/Dockerfile
+++ b/b2handle/tests/Dockerfile
@@ -1,0 +1,18 @@
+# vim:set ft=dockerfile:
+FROM       eudat-b2handle
+
+RUN        apt-get update && apt-get install -y --no-install-recommends \
+           python-coverage \
+           python-mock \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+VOLUME     /opt/B2HANDLE/b2handle/tests
+
+WORKDIR    /opt/B2HANDLE/b2handle/tests
+
+COPY       docker-entrypoint.sh ./
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+CMD        ["coverage"]

--- a/b2handle/tests/README.md
+++ b/b2handle/tests/README.md
@@ -1,0 +1,32 @@
+# B2HANDLE Testing
+
+## Docker
+
+The [Dockerfile](Dockerfile) contains instructions for building a [Docker](https://www.docker.com/) image for running the B2HANDLE test suites.
+
+
+### Base Docker Image
+
+* [eudat-b2handle](../../Dockerfile)
+
+
+### Installation
+
+1. Install [Docker](https://www.docker.com/).
+
+2. Build an image from parent Dockerfile: `cd /path/to/B2HANDLE && docker build -t eudat-b2handle .`
+
+3. Build an image from this Dockerfile: `cd /path/to/B2HANDLE/b2handle/tests && docker build -t eudat-b2handle-tests .`
+
+
+#### Usage
+
+This will run all B2HANDLE unit & integration tests and create an xml-formatted coverage report suitable for Jenkins/SonarQube:
+
+    docker run -it --rm eudat-b2handle-tests
+
+Using the `-v` flag you can also mount a directory from your Docker daemon’s host into the container and gain access to the generated coverage reports, e.g.: 
+
+    docker run -it --rm -v /path/to/B2HANDLE/b2handle/tests:/opt/B2HANDLE/b2handle/tests eudat-b2handle-tests
+
+The above command mounts the host directory, `/path/to/B2HANDLE/b2handle/tests`, into the container at `/opt/B2HANDLE/b2handle/tests`. The `/path/to/B2HANDLE/b2handle/tests` mount overlays but does not remove the pre-existing content. Once the mount is removed, the content is accessible again, including the generated `coverage.xml` file.

--- a/b2handle/tests/docker-entrypoint.sh
+++ b/b2handle/tests/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = 'coverage' ]; then
+  python -m coverage run main_test_script.py
+  python -m coverage xml --include="*/b2handle/*" --omit="*/tests/*"
+else
+  exec "$@"
+fi

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,18 @@
+# vim:set ft=dockerfile:
+FROM       eudat-b2handle
+
+RUN        apt-get update && apt-get install -y --no-install-recommends \
+           make \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN        easy_install pip
+RUN        pip install sphinx
+
+VOLUME     /opt/B2HANDLE/docs
+
+WORKDIR    /opt/B2HANDLE/docs
+
+ENTRYPOINT ["make"]
+
+CMD        ["help"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# B2HANDLE Docs
+
+## Docker
+
+The [Dockerfile](Dockerfile) contains instructions for building a [Docker](https://www.docker.com/) image for building the B2HANDLE documentation using [Sphinx](http://sphinx-doc.org/).
+
+
+### Base Docker Image
+
+* [eudat-b2handle](../Dockerfile)
+
+
+### Installation
+
+1. Install [Docker](https://www.docker.com/).
+
+2. Build an image from parent Dockerfile: `cd /path/to/B2HANDLE && docker build -t eudat-b2handle .`
+
+3. Build an image from this Dockerfile: `cd /path/to/B2HANDLE/docs && docker build -t eudat-b2handle-docs .`
+
+
+#### Usage
+
+To build B2HANDLE docs in standalone HTML files:
+
+    docker run -it --rm eudat-b2handle-docs html
+
+To see all available build options (equivalent to running `make help`):
+
+    docker run -it --rm eudat-b2handle-docs
+
+Using the `-v` flag you can also mount a directory from your Docker daemon’s host into the container and gain access to the generated doc files, e.g.:
+
+    docker run -it --rm -v /path/to/B2HANDLE/docs:/opt/B2HANDLE/docs eudat-b2handle-docs html
+
+The above command mounts the host directory, `/path/to/B2HANDLE/docs`, into the container at `/opt/B2HANDLE/docs`. The `/path/to/B2HANDLE/docs` mount overlays but does not remove the pre-existing content. Once the mount is removed, the content is accessible again, including the generated HTML files under `/path/to/B2HANDLE/docs/build/html`.


### PR DESCRIPTION
This PR adds support for building Docker images for the B2HANDLE library, docs and tests:

#### Library
The (parent) `Dockerfile` contains instructions for building a [Docker](https://www.docker.com/) image with the B2HANDLE library installed (see updated `README.md`).

#### Docs
The `docs/Dockerfile` contains instructions for building a [Docker](https://www.docker.com/) image for building the B2HANDLE documentation using [Sphinx](http://sphinx-doc.org/) (see also `docs/README.md`).

#### Tests
The `b2handle/tests/Dockerfile` contains instructions for building a [Docker](https://www.docker.com/) image for running the B2HANDLE test suites and generating coverage reports (see also `b2handle/tests/README.md`).

The Docker scheme above will provide the following:
* *Rapid application deployment* - Docker containers include the minimal runtime requirements of B2HANDLE, reducing their size and allowing them to be deployed quickly.
* *Portability across machines* - B2HANDLE and all its dependencies are bundled into a single container that is independent from the host machine. The containers can be transferred to another machine that runs Docker, and executed there without compatibility issues.
* *Improved automated building/testing process* - Docker images reduce effort and risk of problems with software dependencies in Jenkins.

In the future, automatically built Docker images with the latest version of B2HANDLE will be shared through a remote repository. GRNET already provides a registry that will probably be used for this purpose, while it is also possible for anyone to configure their own private repository.

/cc @TobiasWeigel, @merretbuurman 