### PR TITLE
Testing with Python 2.6 (Closes #16)

### DIFF
--- a/b2handle/tests/README.md
+++ b/b2handle/tests/README.md
@@ -28,6 +28,19 @@ To generate test coverage reports without `nose`, run:
     coverage xml -i
 
 
+### Notes for older versions of nose and coverage
+
+* Support for branch coverage (`--branch` switch) is only available for Coverage.py version 3.2b1 and above.
+* Sub-command syntax and generating reports in Cobertura-compatible XML format became available in Coverage.py version 3.1b1. With older versions run:
+
+        coverage -e
+        coverage -x main_test_script.py 
+
+    or alternatively, using nose:
+
+        nosetests --cover-erase --cover-inclusive main_test_script.py
+
+
 ## Testing with Docker
 
 The [Dockerfile](Dockerfile) contains instructions for building a [Docker](https://www.docker.com/) image for running the B2HANDLE test suites.

--- a/b2handle/tests/README.md
+++ b/b2handle/tests/README.md
@@ -1,6 +1,34 @@
 # B2HANDLE Testing
 
-## Docker
+## Testing with plain unittest/unittest2
+
+Simply run:
+
+    python main_test_script.py
+
+
+## Testing with nose and/or coverage
+
+If you have installed the B2HANDLE module running `python setup.py install`, [nose](https://pypi.python.org/pypi/nose/) should already be available. Otherwise you can install it using your distribution's package manager or `pip` (recommended) as follows:
+
+    pip install nose
+
+Then run:
+
+    nosetests --with-xunit --xunit-testsuite-name=b2handle --cover-erase --cover-branches --cover-inclusive --cover-xml main_test_script.py
+
+The above will generate test results in the standard XUnit XML format and also provide an XML-formatted coverage report using Ned Batchelder's [Coverage.py](https://pypi.python.org/pypi/coverage). The latter can be installed using `pip` (recommended) as follows:
+
+    pip install coverage
+
+To generate test coverage reports without `nose`, run:
+
+    coverage erase
+    coverage run --branch main_test_script.py
+    coverage xml -i
+
+
+## Testing with Docker
 
 The [Dockerfile](Dockerfile) contains instructions for building a [Docker](https://www.docker.com/) image for running the B2HANDLE test suites.
 
@@ -19,7 +47,7 @@ The [Dockerfile](Dockerfile) contains instructions for building a [Docker](https
 3. Build an image from this Dockerfile: `cd /path/to/B2HANDLE/b2handle/tests && docker build -t eudat-b2handle-tests .`
 
 
-#### Usage
+### Usage
 
 This will run all B2HANDLE unit & integration tests and create an xml-formatted coverage report suitable for Jenkins/SonarQube:
 

--- a/b2handle/tests/clientcredentials_test.py
+++ b/b2handle/tests/clientcredentials_test.py
@@ -1,8 +1,11 @@
 """Tests for the PIDClientCredentials class. No access to any server/servlet/service needed."""
 
-import unittest
-import json
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+import json
 sys.path.append("../..")
 from b2handle.clientcredentials import PIDClientCredentials
 from b2handle.handleexceptions import HandleSyntaxError

--- a/b2handle/tests/handleclient_noaccess_test.py
+++ b/b2handle/tests/handleclient_noaccess_test.py
@@ -1,8 +1,11 @@
 """Testing methods that need no server access."""
 
-import unittest
-import json
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+import json
 sys.path.append("../..")
 import b2handle.handleclient as b2handle
 from b2handle.handleexceptions import HandleSyntaxError

--- a/b2handle/tests/handleclient_readaccess_faked_test.py
+++ b/b2handle/tests/handleclient_readaccess_faked_test.py
@@ -1,9 +1,12 @@
 """Testing methods that normally need Handle server read access,
 by providing a handle record to replace read access."""
 
-import unittest
-import json
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+import json
 sys.path.append("../..")
 from b2handle.handleclient import EUDATHandleClient
 

--- a/b2handle/tests/handleclient_readaccess_patched_test.py
+++ b/b2handle/tests/handleclient_readaccess_patched_test.py
@@ -1,11 +1,14 @@
 """Testing methods that normally need Handle server read access,
 by patching the get request to replace read access."""
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import mock
 from mock import patch
 import json
-import sys
 sys.path.append("../..")
 import b2handle.clientcredentials
 from b2handle.handleclient import EUDATHandleClient

--- a/b2handle/tests/handleclient_search_noaccess_test.py
+++ b/b2handle/tests/handleclient_search_noaccess_test.py
@@ -1,8 +1,11 @@
 """Testing methods that need Handle server write access"""
 
-import unittest
-import json
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+import json
 sys.path.append("../..")
 from b2handle.handleclient import EUDATHandleClient
 from b2handle.handleexceptions import ReverseLookupException

--- a/b2handle/tests/handleclient_writeaccess_patched_test.py
+++ b/b2handle/tests/handleclient_writeaccess_patched_test.py
@@ -1,9 +1,12 @@
 """Testing methods that normally need Handle server read access,
 by patching the get request to replace read access."""
 
-import unittest
-import json
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+import json
 import mock
 from mock import patch
 sys.path.append("../..")

--- a/b2handle/tests/main_test_script.py
+++ b/b2handle/tests/main_test_script.py
@@ -164,5 +164,4 @@ if __name__ == '__main__':
     unittest.TextTestRunner(descriptions=descriptions, verbosity=verbosity).run(test_suites)
 
     # Run with:
-    # python -m coverage run main_test_script.py
-    # python -m coverage report
+    # python main_test_script.py

--- a/b2handle/tests/utilities.py
+++ b/b2handle/tests/utilities.py
@@ -1,7 +1,16 @@
 import logging
 
+class NullHandler(logging.Handler):
+    """
+    For backward-compatibility with Python 2.6, a local class definition
+    is used instead of logging.NullHandler
+    """
+
+    def emit(self, record):
+        pass
+
 REQUESTLOGGER = logging.getLogger('log_all_requests_of_testcases_to_file')
-REQUESTLOGGER.addHandler(logging.NullHandler())
+REQUESTLOGGER.addHandler(NullHandler())
 
 def failure_message(expected, passed, methodname):
     msg = 'The PUT request payload that the method "'+methodname+ '" assembled differs from the expected. This does not necessarily mean that it is wrong, it might just be a different way to talking to the Handle Server. Please run an integration test to check this and update the exptected PUT request accordingly.\nCreated:  '+str(passed)+'\nExpected: '+str(expected)


### PR DESCRIPTION
This PR adds support for running B2HANDLE unit tests with Python 2.6 (see #16).

Changes:
* Add 'NullHandler' class for logging (otherwise not available before Python 2.7)
* Import `unittest2` if Python version < 2.7
* Update test instructions in README and code comments. 

The updated instructions also contain details on the usage of `Coverage.py` for generating test coverage reports.

```
(venv2.6)leia:tests nliam$ python --version
Python 2.6.9
(venv2.6)leia:tests nliam$ pip show coverage
---
Metadata-Version: 2.0
Name: coverage
Version: 4.0.3
Summary: Code coverage measurement for Python
Home-page: https://coverage.readthedocs.org
Author: Ned Batchelder and others
Author-email: ned@nedbatchelder.com
License: Apache 2.0
Location: /Users/nliam/Work/grnet/eudat2020/wp5/src/github/B2HANDLE/venv2.6/lib/python2.6/site-packages
Requires: 
(venv2.6)leia:tests nliam$ coverage run main_test_script.py
Specified test types: ['unit']

Collecting tests:
Number of tests for client (no access required):				29
Number of tests for PIDClientCredentials:					12
Number of tests for searching (without server access):				9
Number of tests for client (faked read access):					15
Number of tests for client's 10320/LOC (faked read access):			7
Number of tests for patched read access:					20
Number of tests for patched write access:					40
Run 132 tests.

Starting tests:
...
----------------------------------------------------------------------
Ran 132 tests in 0.189s

OK
```

/cc @cookie33, can you verify that this works with your Python 2.6 environment?