### PR TITLE
Handle Owner: Added arg 'handleowner' to JSON credentials file.

### DIFF
--- a/b2handle/handleclient.py
+++ b/b2handle/handleclient.py
@@ -83,6 +83,7 @@ class EUDATHandleClient(object):
         # All used attributes (some will be overwritten below)
         self.__username = None
         self.__password = None
+        self.__handle_owner = None
         self.__handle_server_url = 'https://hdl.handle.net'
         self.__default_permissions = '011111110011' # default from hdl-admintool
         self.__can_modify_HS_ADMIN = False
@@ -186,6 +187,14 @@ class EUDATHandleClient(object):
         if revlookup_user is not None and revlookup_pw is not None:
             self.__set_revlookup_auth_string(revlookup_user, revlookup_pw)
 
+        # Handle owner: THe user name to be written into HS_ADMIN.
+        # Can be specified in json credentials file (optionally).
+        # Otherwise, the username used to authenticate is used.
+        if ('handle_owner' in args.keys()) and (args['handle_owner'] is not None):
+            self.__handle_owner = args['handle_owner']
+        else:
+            self.__handle_owner = self.__username
+
         LOGGER.debug(' - (end of initialisation)')
 
     @staticmethod
@@ -280,6 +289,7 @@ class EUDATHandleClient(object):
             credentials.get_server_URL(),
             username=user,
             password=pw,
+            handle_owner=credentials.get_handle_owner(),
             **additional_config
         )
         return inst
@@ -851,13 +861,14 @@ class EUDATHandleClient(object):
 
         # Create admin entry
         list_of_entries = []
-        if not self.__username:
+        if not self.__handle_owner:
             op = 'creating handle without username'
-            msg = 'No username specified. Can not create handle without'+\
-                ' username. Please instantiate the client with a username'
+            msg = 'No username or handle owner specified. Can not create'+\
+                  ' handle without username or handle owner. Please'+\
+                  ' instantiate the client with a username or handle owner.'
             raise IllegalOperationException(op, handle, msg)
         adminentry = self.__create_admin_entry(
-            self.__username,
+            self.__handle_owner,
             self.__default_permissions,
             self.__make_another_index(list_of_entries, hs_admin=True)
         )

--- a/b2handle/tests/clientcredentials_test.py
+++ b/b2handle/tests/clientcredentials_test.py
@@ -50,6 +50,15 @@ class PIDClientCredentialsTestCase(unittest.TestCase):
                                     self.randompassword)
         self.assertIsInstance(inst, PIDClientCredentials)
 
+    def test_credentials_constructor4(self):
+        """Test credentials instantiation. No exception occurs if server url does not exist. """
+        inst = PIDClientCredentials('blablabla',
+                                    self.user,
+                                    self.randompassword,
+                                    'myprefix',
+                                    '300:myhandle/owner')
+        self.assertIsInstance(inst, PIDClientCredentials)
+
 
     def test_credentials_invalid_username(self):
         """Exception occurs when user name is not index:prefix/suffix."""
@@ -57,6 +66,15 @@ class PIDClientCredentialsTestCase(unittest.TestCase):
             inst = PIDClientCredentials(self.url,
                                         self.handle,
                                         self.randompassword)
+
+    def test_credentials_invalid_handleowner(self):
+        """Exception occurs when handle owner is not index:prefix/suffix."""
+        with self.assertRaises(HandleSyntaxError):
+            inst = PIDClientCredentials(self.url,
+                                        self.handle,
+                                        self.randompassword,
+                                        'myprefix',
+                                        '300myhandleowner')
 
     def test_credentials_from_json(self):
         """Test credentials instantiation from JSON file."""

--- a/b2handle/tests/handleclient_writeaccess_patched_test.py
+++ b/b2handle/tests/handleclient_writeaccess_patched_test.py
@@ -11,6 +11,7 @@ import mock
 from mock import patch
 sys.path.append("../..")
 from b2handle.handleclient import EUDATHandleClient
+from b2handle.clientcredentials import PIDClientCredentials
 from b2handle.handleexceptions import HandleAlreadyExistsException
 from b2handle.handleexceptions import HandleAuthenticationError
 from b2handle.handleexceptions import HandleNotFoundException
@@ -99,6 +100,59 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
 
         # Compare with expected payload:
         expected_payload = {"values": [{"index": 100, "type": "HS_ADMIN", "data": {"value": {"index": "999", "handle": "user/name", "permissions": "011111110011"}, "format": "admin"}}, {"index": 1, "type": "URL", "data": "http://foo.bar"}, {"index": 2, "type": "CHECKSUM", "data": "123456"}, {"index": 3, "type": "foo", "data": "foo"}, {"index": 4, "type": "bar", "data": "bar"}, {"index": 5, "type": "10320/LOC", "data": "<locations><location href=\"http://bar.bar\" id=\"0\" /><location href=\"http://foo.foo\" id=\"1\" /></locations>"}]}
+        replace_timestamps(expected_payload)
+        self.assertEqual(passed_payload, expected_payload,
+            failure_message(expected=expected_payload, passed=passed_payload, methodname='register_handle'))
+
+    @patch('b2handle.handleclient.EUDATHandleClient.check_if_username_exists')
+    @patch('b2handle.handleclient.requests.put')
+    @patch('b2handle.handleclient.requests.get')
+    def test_register_handle_different_owner(self, getpatch, putpatch, username_check_patch):
+        """Test registering a new handle with various types of values."""
+
+        # Define the replacement for the patched GET method:
+        # The handle does not exist yet, so a response with 404
+        mock_response_get = MockResponse(notfound=True)
+        getpatch.return_value = mock_response_get
+
+        # Define the replacement for the patched requests.put method:
+        mock_response_put = MockResponse(wascreated=True)
+        putpatch.return_value = mock_response_put
+
+        # Define replacement for the patched check for username existence:
+        username_check_patch = mock.Mock()
+        username_check_patch.response_value = True
+
+        # Make another connector, to add the handle owner:
+        cred = PIDClientCredentials('http://handle.server',
+                                   '999:user/name',
+                                   'apassword',
+                                   'myprefix',
+                                   '300:handle/owner')
+        newInst = EUDATHandleClient.instantiate_with_credentials(cred)
+
+        # Run the code to be tested:
+        testhandle = 'my/testhandle'
+        testlocation = 'http://foo.bar'
+        testchecksum = '123456'
+        additional_URLs = ['http://bar.bar', 'http://foo.foo']
+        handle_returned = newInst.register_handle(testhandle,
+                                                  location=testlocation,
+                                                  checksum=testchecksum,
+                                                  additional_URLs=additional_URLs,
+                                                  foo='foo',
+                                                  bar='bar')
+
+
+        # Check if the PUT request was sent exactly once:
+        self.assertEqual(putpatch.call_count, 1,
+            'The method "requests.put" was not called once, but '+str(putpatch.call_count)+' times.')
+
+        # Get the payload+headers passed to "requests.put"
+        passed_payload, _ = self.get_payload_headers_from_mockresponse(putpatch)
+
+        # Compare with expected payload:
+        expected_payload = {"values": [{"index": 100, "type": "HS_ADMIN", "data": {"value": {"index": "300", "handle": "handle/owner", "permissions": "011111110011"}, "format": "admin"}}, {"index": 1, "type": "URL", "data": "http://foo.bar"}, {"index": 2, "type": "CHECKSUM", "data": "123456"}, {"index": 3, "type": "foo", "data": "foo"}, {"index": 4, "type": "bar", "data": "bar"}, {"index": 5, "type": "10320/LOC", "data": "<locations><location href=\"http://bar.bar\" id=\"0\" /><location href=\"http://foo.foo\" id=\"1\" /></locations>"}]}
         replace_timestamps(expected_payload)
         self.assertEqual(passed_payload, expected_payload,
             failure_message(expected=expected_payload, passed=passed_payload, methodname='register_handle'))

--- a/b2handle/tests/mockresponses.py
+++ b/b2handle/tests/mockresponses.py
@@ -121,7 +121,7 @@ class MockCredentials(object):
     '''
     This is a mocked credentials object.
     '''
-    def __init__(self, config=None, user=None, password=None, url=None, restapi=None):
+    def __init__(self, config=None, user=None, password=None, url=None, restapi=None, handle_owner=None):
         self.config = config
 
         if restapi is not None:
@@ -140,7 +140,13 @@ class MockCredentials(object):
         if url is not None:
             self.url = url
 
+        if handle_owner is not None:
+            self.handle_owner = handle_owner
+        else:
+            self.handle_owner = self.user
+
         self.get_config = mock.MagicMock(return_value=self.config)
         self.get_username = mock.MagicMock(return_value=self.user)
         self.get_password = mock.MagicMock(return_value=self.password)
         self.get_server_URL = mock.MagicMock(return_value=self.url)
+        self.get_handle_owner = mock.MagicMock(return_value=self.handle_owner)


### PR DESCRIPTION
Handle Owner: Added arg 'handleowner' to JSON credentials file.
Also adapted handle creation to use this handleowner in HS_ADMIN, if specified. Added unit tests for this.