### PR TITLE
[WIP] Testing with Python 2.6

### DIFF
--- a/Dockerfile-python2.6
+++ b/Dockerfile-python2.6
@@ -1,0 +1,11 @@
+# vim:set ft=dockerfile:
+FROM       centos:6
+
+RUN        yum -y update && yum clean all && yum -y install \
+           python-setuptools
+
+ADD        . /opt/B2HANDLE
+
+WORKDIR    /opt/B2HANDLE
+
+RUN        python setup.py install

--- a/b2handle/tests/Dockerfile-python2.6
+++ b/b2handle/tests/Dockerfile-python2.6
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+FROM       eudat-b2handle:python2.6
+
+RUN        easy_install pip
+RUN        pip install \
+           argparse \
+           coverage \
+           mock \
+           unittest2
+RUN        pip install setuptools --upgrade
+
+VOLUME     /opt/B2HANDLE/b2handle/tests
+
+WORKDIR    /opt/B2HANDLE/b2handle/tests
+
+COPY       docker-entrypoint.sh ./
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+CMD        ["coverage"]


### PR DESCRIPTION
This PR adds Dockerfiles for building B2HANDLE images with Python 2.6. The base Docker image is [CentOS 6](https://hub.docker.com/_/centos/). The Dockers will be used by Jenkins for running the B2HANDLE tests with Python 2.6.