### PR TITLE
Fixed bug in testing-utilities

### DIFF
--- a/b2handle/tests/handleclient_writeaccess_patched_test.py
+++ b/b2handle/tests/handleclient_writeaccess_patched_test.py
@@ -1196,7 +1196,7 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
         passed_payload, _ = self.get_payload_headers_from_mockresponse(putpatch)
 
         # Compare with expected payload:
-        expected_payload = {"values": [{"index": 1, "ttl": 86400, "type": "URL", "timestamp": "2015-09-30T15:54:31Z", "data": {"value": "www.url.foo", "format": "string"}}, {"index": 2, "type": "10320/LOC", "timestamp": "2015-09-30T15:54:31Z", "data": "<locations><location href=\"http://one\" id=\"0\" /><location href=\"http://two\" id=\"1\" /><location href=\"http://three\" id=\"2\" /></locations>"}]}
+        expected_payload = {"values": [{"index": 1, "ttl": 86400, "type": "URL", "timestamp": "2015-09-30T15:54:31Z", "data": {"value": "www.url.foo", "format": "string"}}, {"index": 2, "type": "10320/LOC", "data": "<locations><location href=\"http://one\" id=\"0\" /><location href=\"http://two\" id=\"1\" /><location href=\"http://three\" id=\"2\" /></locations>"}]}
         replace_timestamps(expected_payload)        
         self.assertEqual(passed_payload, expected_payload,
             failure_message(expected=expected_payload, passed=passed_payload, methodname='add_additional_URL'))

--- a/b2handle/tests/utilities.py
+++ b/b2handle/tests/utilities.py
@@ -21,10 +21,8 @@ def replace_timestamps(jsonobject):
 
     # Replace:
     if type(jsonobject) == type({}):
-        try:
+        if 'timestamp' in jsonobject:
             jsonobject['timestamp'] = 'xxx'
-        except KeyError:
-            pass
 
     # Recursion:
     if type(jsonobject) == type({'b':2}):


### PR DESCRIPTION
Fixed bug in testing-utilities (and had to modify one test): the replace_timestamp method added timestamps instead of replacing.