### PR TITLE
Update test coverage badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# B2HANDLE [![Build Status](https://jenkins.argo.grnet.gr/job/B2HANDLE_devel/badge/icon)](https://jenkins.argo.grnet.gr/job/B2HANDLE_devel) [![Test Coverage](http://jenkins.argo.grnet.gr:9913/jenkins/c/http/jenkins.argo.grnet.gr/job/B2HANDLE_devel)](https://jenkins.argo.grnet.gr/job/B2HANDLE_devel/cobertura/)
+# B2HANDLE [![Build Status](https://jenkins.argo.grnet.gr/job/B2HANDLE_devel/badge/icon)](https://jenkins.argo.grnet.gr/job/B2HANDLE_devel) [![Test Coverage](http://jenkins.argo.grnet.gr:9913/jenkins/c/http/jenkins.argo.grnet.gr/job/B2HANDLE_devel/PYTHON_VERSION=2.7)](https://jenkins.argo.grnet.gr/job/B2HANDLE_devel/PYTHON_VERSION=2.7/cobertura/)
 
 
 ## Docker


### PR DESCRIPTION
This PR updates the test coverage badge URL in README based on the new Jenkins configuration for testing with multiple Python versions.