### PR TITLE
Add nose dependency to test Dockerfiles

### DIFF
--- a/b2handle/tests/Dockerfile
+++ b/b2handle/tests/Dockerfile
@@ -2,7 +2,10 @@
 FROM       eudat-b2handle
 
 RUN        easy_install pip
-RUN        pip install coverage mock
+RUN        pip install \
+           mock \
+           coverage \
+           nose
 
 VOLUME     /opt/B2HANDLE/b2handle/tests
 

--- a/b2handle/tests/Dockerfile-python2.6
+++ b/b2handle/tests/Dockerfile-python2.6
@@ -4,9 +4,10 @@ FROM       eudat-b2handle:python2.6
 RUN        easy_install pip
 RUN        pip install \
            argparse \
-           coverage \
+           unittest2 \
            mock \
-           unittest2
+           coverage \
+           nose
 RUN        pip install setuptools --upgrade
 
 VOLUME     /opt/B2HANDLE/b2handle/tests


### PR DESCRIPTION
This PR adds instructions for installing nose through the Dockerfiles used for running the B2HANDLE unit tests. This will be required after the refactoring of `setup.py` (see PR #44) that will remove nose from `install_requires`. 