### PR TITLE
Fix issues #52 and #53

### DIFF
--- a/b2handle/handleclient.py
+++ b/b2handle/handleclient.py
@@ -856,6 +856,7 @@ class EUDATHandleClient(object):
             handlerecord_json = self.retrieve_handle_record_json(handle)
             if handlerecord_json is not None:
                 msg = 'Could not register handle'
+                LOGGER.error(msg+', as it already exists.')
                 raise HandleAlreadyExistsException(handle=handle, msg=msg)
 
         # Create admin entry

--- a/b2handle/handlesystemconnector.py
+++ b/b2handle/handlesystemconnector.py
@@ -332,6 +332,7 @@ class HandleSystemConnector(object):
         payload = json.dumps({'values':list_of_entries})
         LOGGER.debug('PUT Request payload: '+payload)
         head = self.__get_headers('PUT')
+        LOGGER.debug('PUT Request headers: '+str(head))
         veri = self.__HTTPS_verify
 
         # Make request:

--- a/b2handle/tests/handleclient_writeaccess_patched_test.py
+++ b/b2handle/tests/handleclient_writeaccess_patched_test.py
@@ -153,7 +153,7 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
         passed_payload, _ = self.get_payload_headers_from_mockresponse(putpatch)
 
         # Compare with expected payload:
-        expected_payload = {"values": [{"index": 100, "type": "HS_ADMIN", "data": {"value": {"index": "300", "handle": "handle/owner", "permissions": "011111110011"}, "format": "admin"}}, {"index": 1, "type": "URL", "data": "http://foo.bar"}, {"index": 2, "type": "CHECKSUM", "data": "123456"}, {"index": 3, "type": "FOO", "data": "foo"}, {"index": 4, "type": "BAR", "data": "bar"}, {"index": 5, "type": "10320/LOC", "data": "<locations><location href=\"http://bar.bar\" id=\"0\" /><location href=\"http://foo.foo\" id=\"1\" /></locations>"}]}
+        expected_payload = {"values": [{"index": 100, "type": "HS_ADMIN", "data": {"value": {"index": 300, "handle": "handle/owner", "permissions": "011111110011"}, "format": "admin"}}, {"index": 1, "type": "URL", "data": "http://foo.bar"}, {"index": 2, "type": "CHECKSUM", "data": "123456"}, {"index": 3, "type": "FOO", "data": "foo"}, {"index": 4, "type": "BAR", "data": "bar"}, {"index": 5, "type": "10320/LOC", "data": "<locations><location href=\"http://bar.bar\" id=\"0\" /><location href=\"http://foo.foo\" id=\"1\" /></locations>"}]}
         replace_timestamps(expected_payload)
         self.assertEqual(passed_payload, expected_payload,
             failure_message(expected=expected_payload, passed=passed_payload, methodname='register_handle'))

--- a/b2handle/utilhandle.py
+++ b/b2handle/utilhandle.py
@@ -20,6 +20,7 @@ def remove_index_from_handle(handle_with_index):
 
     split = handle_with_index.split(':')
     if len(split) == 2:
+        split[0] = int(split[0])
         return split
     elif len(split) == 1:
         return (None, handle_with_index)


### PR DESCRIPTION
- Index of username in HS_ADMIN record is now integer, not string (to fix issue #52, which only occured when a "handleowner" was explicitly given and not the default was used)
- If client certificates are used and the first request is a GET, the certificate is sent along, to initialize the session in an authenticated state (to fix issue #53, which occured when client certificates where used and handles were read first, or when handles were written with overwrite=false, as this also first makes a GET request). Fix tested by @cookie33 .
- Unit tests (mocked connections) and integration tests (real reading and writing to server) pass.