### PR TITLE
Https verify can be Boolean or string

### DIFF
--- a/b2handle/handlesystemconnector.py
+++ b/b2handle/handlesystemconnector.py
@@ -18,6 +18,7 @@ from handleexceptions import CredentialsFormatError
 import hsresponses
 import util
 import utilhandle
+import utilconfig
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(util.NullHandler())
@@ -115,7 +116,7 @@ class HandleSystemConnector(object):
 
 
         if args['HTTPS_verify'] is not None:
-            self.__HTTPS_verify = util.get_valid_https_verify(
+            self.__HTTPS_verify = utilconfig.get_valid_https_verify(
                 args['HTTPS_verify']
             )
             LOGGER.info(' - https_verify set to: '+str(self.__HTTPS_verify))

--- a/b2handle/handlesystemconnector.py
+++ b/b2handle/handlesystemconnector.py
@@ -115,7 +115,9 @@ class HandleSystemConnector(object):
 
 
         if args['HTTPS_verify'] is not None:
-            self.__HTTPS_verify = util.string_to_bool(args['HTTPS_verify'])
+            self.__HTTPS_verify = util.get_valid_https_verify(
+                args['HTTPS_verify']
+            )
             LOGGER.info(' - https_verify set to: '+str(self.__HTTPS_verify))
         else:
             self.__HTTPS_verify = defaults['HTTPS_verify']

--- a/b2handle/searcher.py
+++ b/b2handle/searcher.py
@@ -91,7 +91,9 @@ class Searcher(object):
         LOGGER.debug('Setting the attributes:')
 
         if args['HTTPS_verify'] is not None: # Without this check, a passed "False" is not found!
-            self.__HTTPS_verify = util.string_to_bool(args['HTTPS_verify'])
+            self.__HTTPS_verify = util.get_valid_https_verify(
+                args['HTTPS_verify']
+            )
             LOGGER.info(' - https_verify set to: '+str(self.__HTTPS_verify))
         else:
             self.__HTTPS_verify = defaults['HTTPS_verify']

--- a/b2handle/searcher.py
+++ b/b2handle/searcher.py
@@ -13,6 +13,7 @@ import requests
 import json
 import utilhandle
 import util
+import utilconfig
 from handleexceptions import ReverseLookupException
 
 LOGGER = logging.getLogger(__name__)
@@ -91,7 +92,7 @@ class Searcher(object):
         LOGGER.debug('Setting the attributes:')
 
         if args['HTTPS_verify'] is not None: # Without this check, a passed "False" is not found!
-            self.__HTTPS_verify = util.get_valid_https_verify(
+            self.__HTTPS_verify = utilconfig.get_valid_https_verify(
                 args['HTTPS_verify']
             )
             LOGGER.info(' - https_verify set to: '+str(self.__HTTPS_verify))

--- a/b2handle/tests/main_test_script.py
+++ b/b2handle/tests/main_test_script.py
@@ -13,6 +13,7 @@ from handleclient_readaccess_faked_10320_test import EUDATHandleClientReadaccess
 from clientcredentials_test import PIDClientCredentialsTestCase
 from handleclient_search_noaccess_test import EUDATHandleClientSearchNoAccessTestCase
 from handleconnector_access_patched_test import EUDATHandleConnectorAccessPatchedTestCase
+from utilconfig_test import UtilConfigTestCase
 
 # Integration tests:
 # Imports below!
@@ -81,6 +82,10 @@ if __name__ == '__main__':
     print '\nCollecting tests:'
     tests_to_run = []
     numtests = 0
+
+    utilconfig_testcase = unittest.TestLoader().loadTestsFromTestCase(UtilConfigTestCase)
+    tests_to_run.append(utilconfig_testcase)
+    numtests += utilconfig_testcase.countTestCases()
 
     if no_access:
 

--- a/b2handle/tests/util_test.py
+++ b/b2handle/tests/util_test.py
@@ -1,0 +1,29 @@
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from b2handle import util
+
+
+class UtilTestCase(unittest.TestCase):
+
+    def test_valid_https_verify_bool_true(self):
+        """Test return bool True when getting bool True"""
+        self.assertEqual(util.get_valid_https_verify(True), True)
+
+    def test_valid_https_verify_string_true(self):
+        """Test return bool True when getting string True"""
+        self.assertEqual(util.get_valid_https_verify('True'), True)
+
+    def test_valid_https_verify_string_false(self):
+        """Test return bool False when getting string False"""
+        self.assertEqual(util.get_valid_https_verify('False'), False)
+
+    def test_valid_https_verify_bool_string(self):
+        """Test return string when getting a string value in https_verify"""
+        self.assertEqual(
+            util.get_valid_https_verify('ca_cert.crt'),
+            'ca_cert.crt'
+        )

--- a/b2handle/tests/utilconfig_test.py
+++ b/b2handle/tests/utilconfig_test.py
@@ -4,26 +4,26 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 
-from b2handle import util
+from b2handle import utilconfig
 
 
-class UtilTestCase(unittest.TestCase):
+class UtilConfigTestCase(unittest.TestCase):
 
     def test_valid_https_verify_bool_true(self):
         """Test return bool True when getting bool True"""
-        self.assertEqual(util.get_valid_https_verify(True), True)
+        self.assertEqual(utilconfig.get_valid_https_verify(True), True)
 
     def test_valid_https_verify_string_true(self):
         """Test return bool True when getting string True"""
-        self.assertEqual(util.get_valid_https_verify('True'), True)
+        self.assertEqual(utilconfig.get_valid_https_verify('True'), True)
 
     def test_valid_https_verify_string_false(self):
         """Test return bool False when getting string False"""
-        self.assertEqual(util.get_valid_https_verify('False'), False)
+        self.assertEqual(utilconfig.get_valid_https_verify('False'), False)
 
     def test_valid_https_verify_bool_string(self):
         """Test return string when getting a string value in https_verify"""
         self.assertEqual(
-            util.get_valid_https_verify('ca_cert.crt'),
+            utilconfig.get_valid_https_verify('ca_cert.crt'),
             'ca_cert.crt'
         )

--- a/b2handle/tests/utilconfig_test.py
+++ b/b2handle/tests/utilconfig_test.py
@@ -4,26 +4,23 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 
-from b2handle import utilconfig
+from b2handle.utilconfig import get_valid_https_verify
 
 
 class UtilConfigTestCase(unittest.TestCase):
 
     def test_valid_https_verify_bool_true(self):
         """Test return bool True when getting bool True"""
-        self.assertEqual(utilconfig.get_valid_https_verify(True), True)
+        self.assertEqual(get_valid_https_verify(True), True)
 
     def test_valid_https_verify_string_true(self):
         """Test return bool True when getting string True"""
-        self.assertEqual(utilconfig.get_valid_https_verify('True'), True)
+        self.assertEqual(get_valid_https_verify('True'), True)
 
     def test_valid_https_verify_string_false(self):
         """Test return bool False when getting string False"""
-        self.assertEqual(utilconfig.get_valid_https_verify('False'), False)
+        self.assertEqual(get_valid_https_verify('False'), False)
 
     def test_valid_https_verify_bool_string(self):
         """Test return string when getting a string value in https_verify"""
-        self.assertEqual(
-            utilconfig.get_valid_https_verify('ca_cert.crt'),
-            'ca_cert.crt'
-        )
+        self.assertEqual(get_valid_https_verify('ca_cert.crt'), 'ca_cert.crt')

--- a/b2handle/util.py
+++ b/b2handle/util.py
@@ -73,24 +73,24 @@ def check_presence_of_mandatory_args(args, mandatory_args):
     else:
         return True
 
-def string_to_bool(string):
+def get_valid_https_verify(value):
     '''
-    Parses a string to a boolean. Accepts the words
-        "true" and "false" in any mixture of capital
-        andnon-capital letters. If the word is neither
-        "true" nor "false", a KeyError is raised.
+    Get a value that can be the boolean representation of a string
+    or a boolean itself and returns It as a boolean.
+    If this is not the case, It returns a string.
 
-    :string: The string to parse. Passing a boolean
-        does not harm.
-    :returns: True or False.
-    :raise: :exc:`~KeyError`
+    :value: The HTTPS_verify input value
+    :returns: True, False or a string.
     '''
+    http_verify_value = value
+    bool_values = {'false': False, 'true': True}
 
-    dic = {'false':False, 'true':True}
-    if string is True or string is False:
-        return string
-    else:
-        return dic[string.lower()]
+    if isinstance(value, bool):
+        http_verify_value = value
+    elif isinstance(value, str) and value.lower() in bool_values.keys():
+        http_verify_value = bool_values[value.lower()]
+
+    return http_verify_value
 
 def log_instantiation(LOGGER, classname, args, forbidden, with_date=False):
     '''
@@ -120,4 +120,3 @@ def log_instantiation(LOGGER, classname, args, forbidden, with_date=False):
                 LOGGER.debug('Param '+argname+'*******')
             else:
                 LOGGER.debug('Param '+argname+'='+str(args[argname]))
-

--- a/b2handle/util.py
+++ b/b2handle/util.py
@@ -73,25 +73,6 @@ def check_presence_of_mandatory_args(args, mandatory_args):
     else:
         return True
 
-def get_valid_https_verify(value):
-    '''
-    Get a value that can be the boolean representation of a string
-    or a boolean itself and returns It as a boolean.
-    If this is not the case, It returns a string.
-
-    :value: The HTTPS_verify input value
-    :returns: True, False or a string.
-    '''
-    http_verify_value = value
-    bool_values = {'false': False, 'true': True}
-
-    if isinstance(value, bool):
-        http_verify_value = value
-    elif isinstance(value, str) and value.lower() in bool_values.keys():
-        http_verify_value = bool_values[value.lower()]
-
-    return http_verify_value
-
 def log_instantiation(LOGGER, classname, args, forbidden, with_date=False):
     '''
     Log the instantiation of an object to the given logger.

--- a/b2handle/utilconfig.py
+++ b/b2handle/utilconfig.py
@@ -1,0 +1,24 @@
+'''
+This module provides functions to parse
+and validate b2handle configuration
+'''
+
+def get_valid_https_verify(value):
+    '''
+    Get a value that can be the boolean representation of a string
+    or a boolean itself and returns It as a boolean.
+    If this is not the case, It returns a string.
+
+    :value: The HTTPS_verify input value. A string can be passed as a path
+            to a CA_BUNDLE certificate
+    :returns: True, False or a string.
+    '''
+    http_verify_value = value
+    bool_values = {'false': False, 'true': True}
+
+    if isinstance(value, bool):
+        http_verify_value = value
+    elif isinstance(value, str) and value.lower() in bool_values.keys():
+        http_verify_value = bool_values[value.lower()]
+
+    return http_verify_value


### PR DESCRIPTION
I removed **string_to_bool** function, It was only used for **HTTPS_verify**, I changed It for **get_valid_https_verify** which is more accurate now.

I added unittests for several cases with this method.

I couldn't get all the project unittests working, It would be nice if there could be some documentation on what's necessary for all the tests to pass, I couldn't find It in CONTRIBUTING or README files. The Unittests for the method I added pass (util_test.py).

This should close #55. :-)