### PR TITLE
Enable searching for checksum only (without searching for URL)

### DIFF
--- a/b2handle/searcher.py
+++ b/b2handle/searcher.py
@@ -201,6 +201,16 @@ class Searcher(object):
             msg = 'No search terms have been specified. Please specify'+\
                 ' at least one key-value-pair.'
             raise ReverseLookupException(msg=msg)
+        else:
+            isnone = util.return_keys_of_value_none(args)
+            if len(isnone) > 0:
+                LOGGER.debug('search_handle: These keys had value None: '+str(isnone))
+                args = util.remove_value_none_from_dict(args)
+                if len(args) == 0:
+                    LOGGER.debug('search_handle: No key value pair with valid value was specified.')
+                    msg = ('No search terms have been specified. Please specify'
+                           ' at least one key-value-pair.')
+                    raise ReverseLookupException(msg=msg)
 
         # Perform the search:
         list_of_handles = []
@@ -286,10 +296,10 @@ class Searcher(object):
             only_search_for_allowed_keys = True
 
         fulltext_searchterms_given = True
+        fulltext_searchterms = util.remove_value_none_from_list(fulltext_searchterms)
         if len(fulltext_searchterms) == 0:
             fulltext_searchterms_given = False
-        if len(fulltext_searchterms) == 1 and fulltext_searchterms[0] is None:
-            fulltext_searchterms_given = False
+        
         if fulltext_searchterms_given:
             msg = 'Full-text search is not implemented yet.'+\
                 ' The provided searchterms '+str(fulltext_searchterms)+\
@@ -297,10 +307,8 @@ class Searcher(object):
             raise ReverseLookupException(msg=msg)
 
         keyvalue_searchterms_given = True
+        keyvalue_searchterms = util.remove_value_none_from_dict(keyvalue_searchterms)
         if len(keyvalue_searchterms) == 0:
-            keyvalue_searchterms_given = False
-        if len(keyvalue_searchterms) == 1 and\
-            keyvalue_searchterms.itervalues().next() is None:
             keyvalue_searchterms_given = False
 
         if not keyvalue_searchterms_given and not fulltext_searchterms_given:

--- a/b2handle/tests/handleclient_search_noaccess_test.py
+++ b/b2handle/tests/handleclient_search_noaccess_test.py
@@ -66,6 +66,26 @@ class EUDATHandleClientSearchNoAccessTestCase(unittest.TestCase):
         self.assertEqual(query, '?URL=foo',
             'The query is: '+query)
 
+    def test_create_revlookup_query_normal_checksum(self):
+        query = self.searcher.create_revlookup_query(CHECKSUM='foo')
+        self.assertEqual(query, '?CHECKSUM=foo',
+            'The query is: '+query)
+
+    def test_create_revlookup_query_normal_checksum_and_url(self):
+        query = self.searcher.create_revlookup_query(CHECKSUM='foo', URL='bar')
+        self.assertEqual(query, '?URL=bar&CHECKSUM=foo',
+            'The query is: '+query)
+
+    def test_create_revlookup_query_checksum_and_none_url(self):
+        query = self.searcher.create_revlookup_query(CHECKSUM='foo', URL=None)
+        self.assertEqual(query, '?URL=bar&CHECKSUM=foo',
+            'The query is: '+query)
+
+    def test_create_revlookup_query_checksum_and_none_url(self):
+        query = self.searcher.create_revlookup_query(CHECKSUM='foo', URL=None, something=None)
+        self.assertEqual(query, '?CHECKSUM=foo',
+            'The query is: '+query)
+
     def test_instantiate_wrong_search_url(self):
 
         inst = EUDATHandleClient.instantiate_for_read_and_search(

--- a/b2handle/tests/handleclient_searchaccess_test.py
+++ b/b2handle/tests/handleclient_searchaccess_test.py
@@ -189,6 +189,27 @@ class EUDATHandleClientSearchTestCase(unittest.TestCase):
         self.assertEqual(val1, [], 'val1 is: '+str(val1)+', instead of []')
         self.assertEqual(val2, [], 'val2 is: '+str(val2)+', instead of []')
 
+    def test_search_handle_for_checksum(self):
+        """Test searching for checksum with wildcards."""
+        log_new_test_case("test_search_handle_for_checksum")
+
+        log_start_test_code()
+        val1 = self.inst.search_handle(None, CHECKSUM='*1111111111111*')
+
+        log_end_test_code()
+        log_start_test_code()
+        val2 = self.inst.search_handle(URL=None, CHECKSUM='*1111111111111*')
+        log_end_test_code()
+
+        # Check desired outcome:
+        self.assertEqual(type(val1),type([]),
+            'Searching did not return a list, but: '+str(val1)+', type: '+str(type(val1)))
+        self.assertEqual(val1, val2,
+            'Searching with or without keyword did not return the same result:'+\
+            '\nwith keyword: '+str(val1)+'\nwithout: '+str(val2))
+        self.assertEqual(val1, [], 'val1 is: '+str(val1)+', instead of []')
+        self.assertEqual(val2, [], 'val2 is: '+str(val2)+', instead of []')
+
     def test_search_handle_prefixfilter(self):
         """Test filtering for prefixes."""
         log_new_test_case("test_search_handle_prefixfilter")

--- a/b2handle/util.py
+++ b/b2handle/util.py
@@ -73,6 +73,35 @@ def check_presence_of_mandatory_args(args, mandatory_args):
     else:
         return True
 
+def return_keys_of_value_none(dictionary):
+    isnone = []
+    for key,value in dictionary.iteritems():
+        if value is None:
+            isnone.append(key)
+    return isnone
+
+def remove_value_none_from_dict(dictionary):
+    isnone = return_keys_of_value_none(dictionary)
+    if len(isnone) > 0:
+        for nonekey in isnone:
+            dictionary.pop(nonekey)
+    return dictionary
+
+def return_indices_of_value_none(mylist):
+    isnone = []
+    for i in xrange(len(mylist)):
+        if mylist[i] is None:
+            isnone.append(i)
+    return isnone
+
+def remove_value_none_from_list(mylist):
+    isnone = return_indices_of_value_none(mylist)
+    if len(isnone) > 0:
+        for index in isnone:
+            mylist.pop(index)
+    return mylist
+
+
 def log_instantiation(LOGGER, classname, args, forbidden, with_date=False):
     '''
     Log the instantiation of an object to the given logger.


### PR DESCRIPTION
This enables searching for checksum or other keys without searching for URL.
This fixes issue #69 . Unit tests pass (tested under python 2.7). Integration with search servlet was tested by @cookie33 .