### PR TITLE
modify handles with index updates instead of rewriting complete handle

### DIFF
--- a/b2handle/handleclient.py
+++ b/b2handle/handleclient.py
@@ -61,8 +61,8 @@ class EUDATHandleClient(object):
         :param REST_API_url_extension: Optional. The extension of a Handle
             Server's URL to access its REST API. Defaults to '/api/handles/'.
         :param allowed_search_keys: Optional. The keys that can be used for
-            reverse lookup of handles, as a list of strings. Defaults to 'URL'
-            and 'CHECKSUM'. If the list is empty, all keys are passed to the
+            reverse lookup of handles, as a list of strings. Defaults to 'url'
+            and 'checksum'. If the list is empty, all keys are passed to the
             reverse lookup servlet and exceptions are passed on to the user.
         :param 10320LOC_chooseby: Optional. The value to give to a handle
             record's 10320/LOC entry's 'chooseby' attribute as string (e.g.
@@ -70,10 +70,8 @@ class EUDATHandleClient(object):
         :param modify_HS_ADMIN: Optional. Advanced usage. Determines whether
             the HS_ADMIN handle record entry can be modified using this library.
             Defaults to False and should not be modified.
-        :param HTTPS_verify: Optional. This parameter can have three values.
-            'True', 'False' or 'the path to a CA_BUNDLE file or directory with
-            certificates of trusted CAs'. If set to False, the certificate is
-            not verified in HTTP requests. Defaults to True.
+        :param HTTPS_verify: Optional. If set to False, the certificate is not
+            verified in HTTP requests. Defaults to True.
         :param reverselookup_baseuri: Optional. The base URL of the reverse
             lookup service. If not set, the handle server base URL is used.
         :param reverselookup_url_extension: Optional. The path to append to
@@ -562,23 +560,22 @@ class EUDATHandleClient(object):
                     changed = True
                     nothingchanged = False
 
-        # Add the unchanged values
-        for i in xrange(len(list_of_entries)):
-            if list_of_entries[i]['type'] not in keys:
-                new_list_of_entries.append(list_of_entries[i])
+        # Add the indices
+        indices = []
+        for i in xrange(len(new_list_of_entries)):
+            indices.append(new_list_of_entries[i]['index'])
 
-        # Overwrite the old record:
+        # append to the old record:
         if nothingchanged:
             LOGGER.debug('modify_handle_value: There was no entries '+\
                 str(kvpairs.keys())+' to be modified (handle '+handle+').'+\
                 ' To add them, set add_if_not_exist = True')
         else:
-            # TODO FIXME: Implement overwriting by index (less risky),
-            # once HS have fixed the issue with the indices.
             op = 'modifying handle values'
             resp, put_payload = self.__send_handle_put_request(
                 handle,
                 new_list_of_entries,
+                indices=indices,
                 overwrite=True,
                 op=op)
             if hsresponses.handle_success(resp):
@@ -1036,8 +1033,8 @@ class EUDATHandleClient(object):
         :param handle: The handle.
         :param list_of_entries: A list of handle record entries to be written,
          in the format [{"index":xyz, "type":"xyz", "data":"xyz"}] or similar.
-        :param indices: Optional. A list of indices to delete. Defaults
-         to None (i.e. the entire handle is deleted.). The list can
+        :param indices: Optional. A list of indices to modify. Defaults
+         to None (i.e. the entire handle is updated.). The list can
          contain integers or strings.
         :param overwrite: Optional. Whether the handle should be overwritten
          if it exists already.

--- a/b2handle/handleclient.py
+++ b/b2handle/handleclient.py
@@ -61,8 +61,8 @@ class EUDATHandleClient(object):
         :param REST_API_url_extension: Optional. The extension of a Handle
             Server's URL to access its REST API. Defaults to '/api/handles/'.
         :param allowed_search_keys: Optional. The keys that can be used for
-            reverse lookup of handles, as a list of strings. Defaults to 'url'
-            and 'checksum'. If the list is empty, all keys are passed to the
+            reverse lookup of handles, as a list of strings. Defaults to 'URL'
+            and 'CHECKSUM'. If the list is empty, all keys are passed to the
             reverse lookup servlet and exceptions are passed on to the user.
         :param 10320LOC_chooseby: Optional. The value to give to a handle
             record's 10320/LOC entry's 'chooseby' attribute as string (e.g.
@@ -70,8 +70,10 @@ class EUDATHandleClient(object):
         :param modify_HS_ADMIN: Optional. Advanced usage. Determines whether
             the HS_ADMIN handle record entry can be modified using this library.
             Defaults to False and should not be modified.
-        :param HTTPS_verify: Optional. If set to False, the certificate is not
-            verified in HTTP requests. Defaults to True.
+        :param HTTPS_verify: Optional. This parameter can have three values.
+            'True', 'False' or 'the path to a CA_BUNDLE file or directory with
+            certificates of trusted CAs'. If set to False, the certificate is
+            not verified in HTTP requests. Defaults to True.
         :param reverselookup_baseuri: Optional. The base URL of the reverse
             lookup service. If not set, the handle server base URL is used.
         :param reverselookup_url_extension: Optional. The path to append to

--- a/b2handle/handlesystemconnector.py
+++ b/b2handle/handlesystemconnector.py
@@ -538,7 +538,6 @@ class HandleSystemConnector(object):
         if indices is None:
             indices = []
         if len(indices) > 0:
-            url = url+'?'
             for index in indices:
                 url = url+separator+'index='+str(index)
                 separator = '&'

--- a/b2handle/handlesystemconnector.py
+++ b/b2handle/handlesystemconnector.py
@@ -526,6 +526,7 @@ class HandleSystemConnector(object):
          'http://some.handle.server/api/handles/prefix/suffix?index=2&index=6&overwrite=false
         '''
         LOGGER.debug('make_handle_URL...')
+        separator = '?'
 
         if other_url is not None:
             url = other_url
@@ -539,19 +540,15 @@ class HandleSystemConnector(object):
         if len(indices) > 0:
             url = url+'?'
             for index in indices:
-                url = url+'&index='+str(index)
+                url = url+separator+'index='+str(index)
+                separator = '&'
 
         if overwrite is not None:
-            if overwrite and len(indices) > 0:
-                url = url+'&overwrite=true'
-            elif overwrite:
-                url = url+'?overwrite=true'
-            elif len(indices) > 0:
-                url = url+'&overwrite=false'
+            if overwrite:
+                url = url+seperator+'overwrite=true'
             else:
-                url = url+'?overwrite=false'
+                url = url+separator+'overwrite=false'
 
-        url = url.replace('?&', '?')
         return url
 
     def __log_request_response_to_file(self, **args):

--- a/b2handle/handlesystemconnector.py
+++ b/b2handle/handlesystemconnector.py
@@ -336,24 +336,6 @@ class HandleSystemConnector(object):
         op = args['op']
         overwrite = args['overwrite'] or False
 
-        # Overwrite by index:
-        if indices is not None and len(indices) > 0:
-            LOGGER.debug('__send_handle_put_request: Putting values '+str(indices)+' to handle '+handle+'.')
-        else:
-            LOGGER.debug('__send_handle_put_request: Putting handle '+handle+'.')
-#         if indices is not None:
-#            message = 'Writing handle values by index is not implemented'+\
-#                ' yet because the way the indices are interpreted by the'+\
-#                ' Handle Server may be modified soon. The entire handle'+\
-#                ' record has to be overwritten.'
-#            raise NotImplementedError(message)
-#            # TODO FIXME: As soon as the Handle System uses the correct indices
-#            # for overwriting, this may be implemented.
-#            # In HSv8 beta, the HS uses ?index=3 for overwriting index:4. If the
-#            # library used this and then the behaviour is changed, it would lead
-#            # to corrupt handle records, so we wait until the issue is fixed by
-#            # the Handle System.
-
         # Make necessary values:
         url = self.make_handle_URL(handle, indices, overwrite=overwrite)
         LOGGER.debug('PUT Request to '+url)

--- a/b2handle/handlesystemconnector.py
+++ b/b2handle/handlesystemconnector.py
@@ -545,7 +545,7 @@ class HandleSystemConnector(object):
 
         if overwrite is not None:
             if overwrite:
-                url = url+seperator+'overwrite=true'
+                url = url+separator+'overwrite=true'
             else:
                 url = url+separator+'overwrite=false'
 

--- a/b2handle/hsresponses.py
+++ b/b2handle/hsresponses.py
@@ -11,8 +11,7 @@ Author: Merret Buurman (DKRZ), 2015-2016
 import json
 
 def handle_success(response):
-    # TODO May be misleading - 201 Created is also success!
-    if response.status_code == 200 and json.loads(response.content)["responseCode"] == 1:
+    if (response.status_code == 200 or response.status_code == 201) and json.loads(response.content)["responseCode"] == 1:
         return True
     return False
 

--- a/b2handle/tests/handleclient_writeaccess_patched_test.py
+++ b/b2handle/tests/handleclient_writeaccess_patched_test.py
@@ -271,7 +271,7 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
 
         # Define the replacement for the patched requests.put method:
         cont = {"responseCode":1,"handle":"my/testhandle"}
-        mock_response_put = MockResponse(status_code=200, content=json.dumps(cont))
+        mock_response_put = MockResponse(status_code=201, content=json.dumps(cont))
         putpatch.return_value = mock_response_put
 
         # Run the method to be tested:
@@ -286,7 +286,7 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
         passed_payload, _ = self.get_payload_headers_from_mockresponse(putpatch)
 
         # Compare with expected payload:
-        expected_payload = {"values": [{"index": 4, "ttl": 86400, "type": "TEST4", "data": "newvalue"}, {"index": 111, "ttl": 86400, "type": "TEST1", "timestamp": "2015-09-30T13:57:03Z", "data": {"value": "val1", "format": "string"}}, {"index": 2222, "ttl": 86400, "type": "TEST2", "timestamp": "2015-09-30T13:57:03Z", "data": {"value": "val2", "format": "string"}}, {"index": 333, "ttl": 86400, "type": "TEST3", "timestamp": "2015-09-30T13:57:03Z", "data": {"value": "val3", "format": "string"}}]}
+        expected_payload = {"values": [{"index": 4, "ttl": 86400, "type": "TEST4", "data": "newvalue"}]}
         replace_timestamps(expected_payload)
         self.assertEqual(passed_payload, expected_payload,
             failure_message(expected=expected_payload,
@@ -369,15 +369,6 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
         expected_payload = {
         "values":[
             {
-                "index":111,
-                "type": "TEST1",
-                "data":{
-                    "format":"string",
-                    "value":"val1"
-                },
-                "ttl":86400,
-                "timestamp":"2015-09-29T15:51:08Z"
-            },{
                 "index":2222,
                 "type": "TEST2",
                 "data":"new2",
@@ -413,7 +404,7 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
 
         # Define the replacement for the patched requests.put method:
         cont = {"responseCode":1,"handle":"my/testhandle"}
-        mock_response_put = MockResponse(status_code=200, content=json.dumps(cont))
+        mock_response_put = MockResponse(status_code=201, content=json.dumps(cont))
         putpatch.return_value = mock_response_put
 
         # Call the method to be tested: Modifying corrupted raises exception:
@@ -480,7 +471,7 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
         passed_payload, _ = self.get_payload_headers_from_mockresponse(putpatch)
 
         # Compare with expected payload:
-        expected_payload = {"values": [{"index": 2, "type": "TEST100", "data": "new100"}, {"index": 2222, "ttl": 86400, "type": "TEST2", "data": "new2"}, {"index": 4, "ttl": 86400, "type": "TEST4", "data": "new4"}, {"index": 111, "ttl": 86400, "type": "TEST1", "timestamp": "2015-09-30T20:38:59Z", "data": {"value": "val1", "format": "string"}}, {"index": 333, "ttl": 86400, "type": "TEST3", "timestamp": "2015-09-30T20:38:59Z", "data": {"value": "val3", "format": "string"}}]}
+        expected_payload = {"values": [{"index": 2, "type": "TEST100", "data": "new100"}, {"index": 2222, "ttl": 86400, "type": "TEST2", "data": "new2"}, {"index": 4, "ttl": 86400, "type": "TEST4", "data": "new4"}]}
         replace_timestamps(expected_payload)
         self.assertEqual(passed_payload, expected_payload,
             failure_message(expected=expected_payload,
@@ -520,8 +511,7 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
         passed_payload, _ = self.get_payload_headers_from_mockresponse(putpatch)
 
         # Compare with expected payload:
-        #expected_payload = {"values": [{"index": 2, "type": "TEST101", "data": "new101"},{"index": 3, "type": "TEST100", "data": "new100"}, {"index": 2222, "ttl": 86400, "type": "TEST2", "data": "new2"}, {"index": 4, "ttl": 86400, "type": "TEST4", "data": "new4"}, {"index": 111, "ttl": 86400, "type": "TEST1", "timestamp": "2015-09-30T20:38:59Z", "data": {"value": "val1", "format": "string"}}, {"index": 333, "ttl": 86400, "type": "TEST3", "timestamp": "2015-09-30T20:38:59Z", "data": {"value": "val3", "format": "string"}}]}
-        expected_payload = {'values': [{'index': 2, 'type': 'TEST100', 'data': 'new100'}, {'index': 2222, 'ttl': 86400, 'type': 'TEST2', 'data': 'new2'}, {'index': 4, 'ttl': 86400, 'type': 'TEST4', 'data': 'new4'}, {'index': 3, 'type': 'TEST101', 'data': 'new101'}, {'index': 111, 'ttl': 86400, 'type': 'TEST1', 'timestamp': 'xxx', 'data': {'value': 'val1', 'format': 'string'}}, {'index': 333, 'ttl': 86400, 'type': 'TEST3', 'timestamp': 'xxx', 'data': {'value': 'val3', 'format': 'string'}}]}
+        expected_payload = {'values': [{'index': 2, 'type': 'TEST100', 'data': 'new100'}, {'index': 2222, 'ttl': 86400, 'type': 'TEST2', 'data': 'new2'}, {'index': 4, 'ttl': 86400, 'type': 'TEST4', 'data': 'new4'}, {'index': 3, 'type': 'TEST101', 'data': 'new101'}]}
         replace_timestamps(expected_payload)
         self.assertEqual(passed_payload, expected_payload,
             failure_message(expected=expected_payload,


### PR DESCRIPTION
Implement modifying handle records by modifying/adding entries instead of rewriting a whole handle.

Before a handle update in the function: modify_handle_value was done by rewriting the whole handle. Now it is implemented by using the ?index=number url method and will only update/add the values specified in the index.

As a side effect the function: make_handle_URL is fixed.

Needs to be tested firmly before adding to codebase.