### PR TITLE
Fixes to unit tests

### DIFF
--- a/b2handle/tests/handleclient_search_noaccess_test.py
+++ b/b2handle/tests/handleclient_search_noaccess_test.py
@@ -21,9 +21,10 @@ class EUDATHandleClientSearchNoAccessTestCase(unittest.TestCase):
 
     def setUp(self):
         self.inst = EUDATHandleClient()
+        self.inst._EUDATHandleClient__searcher._Searcher__has_search_access = True # fake search access
         self.searcher = Searcher()
+        self.searcher._Searcher__has_search_access = True # Fake search access
  
-
     def tearDown(self):
         pass
 

--- a/b2handle/tests/main_test_script.py
+++ b/b2handle/tests/main_test_script.py
@@ -86,6 +86,7 @@ if __name__ == '__main__':
 
         utilconfig_testcase = unittest.TestLoader().loadTestsFromTestCase(UtilConfigTestCase)
         tests_to_run.append(utilconfig_testcase)
+        n = utilconfig_testcase.countTestCases()
         numtests += utilconfig_testcase.countTestCases()
         print 'Number of tests for utilconfig (no access required):\t\t\t\t'+str(n)
 

--- a/b2handle/tests/main_test_script.py
+++ b/b2handle/tests/main_test_script.py
@@ -82,11 +82,12 @@ if __name__ == '__main__':
     tests_to_run = []
     numtests = 0
 
-    utilconfig_testcase = unittest.TestLoader().loadTestsFromTestCase(UtilConfigTestCase)
-    tests_to_run.append(utilconfig_testcase)
-    numtests += utilconfig_testcase.countTestCases()
-
     if no_access:
+
+        utilconfig_testcase = unittest.TestLoader().loadTestsFromTestCase(UtilConfigTestCase)
+        tests_to_run.append(utilconfig_testcase)
+        numtests += utilconfig_testcase.countTestCases()
+        print 'Number of tests for utilconfig (no access required):\t\t\t\t'+str(n)
 
         noaccess = unittest.TestLoader().loadTestsFromTestCase(EUDATHandleClientNoaccessTestCase)
         tests_to_run.append(noaccess)

--- a/b2handle/tests/main_test_script.py
+++ b/b2handle/tests/main_test_script.py
@@ -22,12 +22,11 @@ from utilconfig_test import UtilConfigTestCase
 log_b2handle = False
 if log_b2handle == True:
     LOGGER = logging.getLogger()
-    LOGGER.setLevel("DEBUG")
-    LOGGER.addHandler(
-        logging.FileHandler(
-            'logs_b2handle'+time.strftime("%Y-%m-%d_%H-%M")+'.txt', mode='a+'
-        )
-    )
+    LOGGER.setLevel(logging.DEBUG)
+    file_handler = logging.FileHandler('logs_b2handle'+time.strftime("%Y-%m-%d_%H-%M")+'.txt', mode='a+')
+    file_handler.setFormatter(logging.Formatter('%(levelname)s:%(module)s:%(message)s'))
+    LOGGER.addHandler(file_handler)
+
 
 
 if __name__ == '__main__':

--- a/b2handle/tests/mockresponses.py
+++ b/b2handle/tests/mockresponses.py
@@ -130,7 +130,8 @@ class MockCredentials(object):
         handleowner=None,
         private_key=None,
         certificate_and_key=None,
-        certificate_only=None
+        certificate_only=None,
+        prefix=None
     ):
 
         self.config = config
@@ -160,6 +161,20 @@ class MockCredentials(object):
         else:
             self.handleowner = self.user
 
+        self.prefix=prefix
+
+        self.all_config = {}
+        self.all_config.update(self.config)
+        self.all_config['username'] = self.user
+        self.all_config['password'] = self.password
+        self.all_config['handleowner'] = self.handleowner
+        self.all_config['handle_server_url'] = self.url
+        self.all_config['private_key'] = self.key
+        self.all_config['certificate_only'] = self.cert
+        self.all_config['certificate_and_key'] = self.cert_and_key
+        self.all_config['prefix'] = self.prefix
+
+
         self.get_config = mock.MagicMock(return_value=self.config)
         self.get_username = mock.MagicMock(return_value=self.user)
         self.get_password = mock.MagicMock(return_value=self.password)
@@ -168,3 +183,4 @@ class MockCredentials(object):
         self.get_path_to_private_key = mock.MagicMock(return_value=self.key)
         self.get_path_to_file_certificate_only = mock.MagicMock(return_value=self.cert)
         self.get_path_to_file_certificate_and_key = mock.MagicMock(return_value=self.cert_and_key)
+        self.get_all_args = mock.MagicMock(return_value=self.all_config)


### PR DESCRIPTION
- Fixed mocked-up credentials (they were not updated in PR #91 , which lead to failing unit tests).
- Fixed unit tests that involved searching while search module had no access to a search servlet (also broken since #91).
- Small improvements, e.g. in logging unit tests