### PR TITLE
Corrected version to 1.0.3, as the changes were backward compatible.

### DIFF
--- a/b2handle/__init__.py
+++ b/b2handle/__init__.py
@@ -1,3 +1,3 @@
 #
 # The version as used in setup.py and docs/source/conf.py
-__version__ = "1.1"
+__version__ = "1.0.3"


### PR DESCRIPTION
CORRECTION.
The version was set to 1.1.0 even though the changes since 1.0.2 are backward compatible bug fixes. So to adhere to the rules of Semantic Versioning, we correct the version to 1.0.3.