### PR TITLE
Cleaned help(b2handle) output

### DIFF
--- a/b2handle/__init__.py
+++ b/b2handle/__init__.py
@@ -1,3 +1,11 @@
-#
-# The version as used in setup.py and docs/source/conf.py
+
 __version__ = "1.0.3"
+
+# The version as used in setup.py and docs/source/conf.py.
+
+# IMPORTANT
+# Please put no comment above the __version__ variable,
+# as they would be printed in the help(b2handle) output!
+# (The first comment - empty or not - would be appended to 
+# the package name, the next non-empty comment would be
+# printed as description).


### PR DESCRIPTION
The comments inside the __init__.py were interpreted as docstrings and got printed in the help(b2handle) output, so I moved them to below the code.
Things like Author, Author Email, Long Description are still missing from the help(b2handle) output.