### PR TITLE
ARGO-2271 Fix docker image to get specific setuptools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ FROM       debian:jessie
 RUN        apt-get update && apt-get install -y --no-install-recommends \
            ca-certificates \
            python \
-           python-setuptools \
+           python-pip \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
+
+RUN     pip install -U pip && \
+        pip install -Iv setuptools==44.0.0
 
 ADD        . /opt/B2HANDLE
 


### PR DESCRIPTION
Python setuptools has dropped support for python 2 that means that by installing any new version of the setup tools package in our dockerfiles will fail. I added the latest version of the setup tools that support python2.7 and built it locally. 