### PR TITLE
Update handleclient_write_patched_unit_test.py

### DIFF
--- a/b2handle/tests/testcases/handleclient_write_patched_unit_test.py
+++ b/b2handle/tests/testcases/handleclient_write_patched_unit_test.py
@@ -997,7 +997,9 @@ class EUDATHandleClientWriteaccessPatchedTestCase(unittest.TestCase):
     @mock.patch('b2handle.handlesystemconnector.requests.Session.get')
     def test_add_additional_URL_another(self, getpatch, putpatch):
         """Test adding an additional URL."""
-
+        # needed for the new versions of python for assertion . 
+        maxDiff = None
+        
         # Define the replacement for the patched GET method:
         cont = {"responseCode":1, "handle":"my/testhandle", "values":[{"index":1, "type":"URL", "data":{"format":"string", "value":"www.url.foo"}, "ttl":86400, "timestamp":"2015-09-30T15:54:30Z"}, {"index":2, "type":"10320/LOC", "data":{"format":"string", "value":"<locations><location href = 'http://first.foo' /><location href = 'http://second.foo' /></locations> "}, "ttl":86400, "timestamp":"2015-09-30T15:54:30Z"}]}
         mock_response_get = MockResponse(status_code=200, content=json.dumps(cont))


### PR DESCRIPTION
to support the error in python 3.9
'AssertionError: {'val[17 chars]1, 'type': 'URL', 'data': {'format': 'string',[276 chars]x'}]} != {'val[17 chars]1, 'ttl': 86400, 'type': 'URL', 'timestamp': '[276 chars]>'}]}

Diff is 800 characters long. Set self.maxDiff to None to see it. : The PUT request payload that the method "add_additional_URL" assembled differs from the expected. This does not necessarily mean that it is wrong, it might just be a different way to talking to the Handle Server. Please run an integration test to check this and update the exptected PUT request accordingly.'