### PR TITLE
Close the requests session when the connector is deleted.

### DIFF
--- a/b2handle/handlesystemconnector.py
+++ b/b2handle/handlesystemconnector.py
@@ -83,8 +83,12 @@ class HandleSystemConnector(object):
             self.__setup_for_writeaccess(args)
 
         LOGGER.debug('End of instantiation of the handle system connector.')
-
-
+        
+    # Delete sessions : Close the requests session when the connector is deleted.
+    def __del__(self):
+        self.__session.close()
+        
+        
     # Helpers for init method:
 
     def __store_args_or_set_to_defaults(self, args, defaults):


### PR DESCRIPTION
I've seen the following warnings when multiple clients are instantiated and destroyed relatively quickly (e.g. in a unit test that creates and removes handles from a live server):

ResourceWarning: unclosed <ssl.SSLSocket fd=1092, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('xxx.xxx.xxx.xxx', 65255), raddr=('xxx.xxx.xxx.xxx', 8000)>
These unclosed sockets can easily be cleaned up by calling session.close() on the requests session when the HandleSystemConnector object is deleted.